### PR TITLE
Changed max zoom on map to 19 for ease of viewing on auto-zoom

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ $(document).ready(function () {
       ],
       view: new ol.View({
         center: ol.proj.fromLonLat([-73.935242, 40.730610]),
-        maxZoom: 20,
+        maxZoom: 19,
         zoom: 10
       })
     });


### PR DESCRIPTION
JS: 

- decreased maximum zoom. This will make the view upon auto-zooming to a dropped pin easier to read/interpret.