### PR TITLE
Removed link to geocoder

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,6 @@
 <!--Import JQuery library-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/ol-geocoder"></script>  
 <script src="config.js"></script>
 <script src="script.js"></script>
 </body>


### PR DESCRIPTION
HTML:

Removed (hopefully) the last standing link to the deprecated geocoder library